### PR TITLE
tried to set up destroy action in comment controller

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
   def create
+    # binding.pry
     joke = Joke.find(params[:joke_id])
     comment = Comment.new(joke_comment_params)
     comment.joke_id = joke.id
@@ -10,6 +11,15 @@ class CommentsController < ApplicationController
   end
 
   def destroy
+    binding.pry
+    # joke_idは送られてきている。
+    # しかし、comment_idがnilになっている
+    # したがってcomment_idを特定して削除することができなくなっている。
+    joke = Joke.find(params[:joke_id])
+    # comment = Comment.find(params[:comment_id])
+    comment = current_user.comments.find_by(comment_id: comment.id)
+    comment.destroy
+    redirect_to joke_path(params[:joke_id])
   end
 end
 private

--- a/app/views/jokes/show.html.erb
+++ b/app/views/jokes/show.html.erb
@@ -20,6 +20,9 @@
 	<p>jokeに紐づいたコメントの表示</p>
 	<% @comments.each do |comment| %>
 	    <%= comment.body %>
+	    <% if comment.user_id == current_user.id %>
+	    	<%= link_to "コメントを削除する", joke_comments_path(comment.joke.id), method: :delete, "data-confirm"=> "こちらのコメントを本当に削除しますか?" %>
+	    <% end %>
     <% end %>
 
     <p></p>


### PR DESCRIPTION
comment controllerのdestroyアクションを修正中
jokes/showに複数表示されているコメントの中にある
自分のコメントの削除機能を実装中
paramsの中身を見て見ると、
joke_idは送られてきている。
しかし、comment_idがnilになっている
従って、comment_idを特定して削除することができなくなっている。